### PR TITLE
Tradução gradlew

### DIFF
--- a/gradlew
+++ b/gradlew
@@ -27,7 +27,7 @@ cd "$SAVED" >/dev/null
 APP_NAME="Gradle"
 APP_BASE_NAME=`basename "$0"`
 
-# Add default JVM options here. You can also use JAVA_OPTS and GRADLE_OPTS to pass JVM options to this script.
+# Adicione opções JVM padrão aqui. Você também pode usar JAVA_OPTS e GRADLE_OPTS para passar opções JVM para este script.
 DEFAULT_JVM_OPTS=""
 
 # Use the maximum available, or set MAX_FD != -1 to use that value.


### PR DESCRIPTION
Markdown é uma linguagem de marcação leve usada para formatar texto de maneira simples e intitiva. Ela  permite criar documentos com negrito, itálico, links, listas, títulos e muito mais, sem precisar de códigos HTML complexos.